### PR TITLE
Replaced department ID with title on course-retrieve API

### DIFF
--- a/academic/api/views.py
+++ b/academic/api/views.py
@@ -30,6 +30,6 @@ class CourseViewSet(ModelViewSet):
         return [permission() for permission in permission_classes]
 
     def get_serializer_class(self):
-        if self.action == "list":
+        if self.action in ["list", "retrieve"]:
             return CourseListSerializer
         return CourseSerializer

--- a/academic/tests/test_views/test_course_viewset.py
+++ b/academic/tests/test_views/test_course_viewset.py
@@ -86,6 +86,10 @@ class CollegeAdminCourseViewSetTestCase(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["title"], self.course.title)
+        self.assertEqual(
+            response.data["results"][0]["department"], self.course.department.title
+        )
 
     def test_college_admin_create_course(self):
         url = reverse("course-list")
@@ -105,6 +109,7 @@ class CollegeAdminCourseViewSetTestCase(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["title"], self.course.title)
+        self.assertEqual(response.data["department"], self.course.department.title)
 
     def test_college_admin_update_course(self):
         url = reverse("course-detail", kwargs={"pk": self.course.pk})
@@ -118,6 +123,7 @@ class CollegeAdminCourseViewSetTestCase(APITestCase):
         response = self.client.put(url, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["title"], "Computer Science")
+        self.assertEqual(response.data["department"], self.course.department.id)
 
     def test_college_admin_delete_course(self):
         url = reverse("course-detail", kwargs={"pk": self.course.pk})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified `get_serializer_class` method to return `CourseListSerializer` for both "list" and "retrieve" actions.
	- Added assertions for `title` and `department` fields in response data for specific test methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->