### PR TITLE
Remove Docker image build and push commands from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ help:
 	@echo "  db.migration.migrate - Create django migrations and migrate to database"
 	@echo "  db.migration.clean   - Remove all django migrations (Dangerous!)"
 	@echo "  db.volume.delete     - Delete database volume"
-	@echo "  docker.image.build   - Build docker image"
-	@echo "  docker.image.push    - Push docker image to registry"
 	@echo "  code.format          - Format code using black, isort and flake8"
 	@echo "  git.prune.deleted    - Delete local branches that have been deleted on remote"
 
@@ -18,15 +16,6 @@ help:
 docker.image.build:
 	docker compose down
 	docker build -t clg_mgmt_tenant-django:1.0 .
-	docker tag clg_mgmt_tenant-django:1.0 ghcr.io/pvfarooq/college-management-tenant/clg_mgmt_tenant-django:1.0
-
-.PHONY: docker.image.push
-docker.image.push:
-	docker push ghcr.io/pvfarooq/college-management-tenant/clg_mgmt_tenant-django:1.0
-
-.PHONY: github.docker.login
-github.docker.login:
-	docker login ghcr.io -u pvfarooq
 
 
 .PHONY: db.migration.migrate

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ argon2-cffi==23.1.0
 ipython==8.23.0
 drf-yasg==1.21.7
 django-filter==23.5
+setuptools


### PR DESCRIPTION
This pull request includes changes to the `Makefile` and `requirements/base.txt` files, focusing on the removal of certain Docker-related tasks and the addition of a new dependency.

Changes to `Makefile`:

* Removed the help descriptions for `docker.image.build` and `docker.image.push`.
* Removed the `docker.image.push` and `github.docker.login` tasks, along with their associated commands.

Changes to `requirements/base.txt`:

* Added `setuptools` to the list of dependencies.